### PR TITLE
Added exception in case of curl error

### DIFF
--- a/src/Alexsoft/Curl.php
+++ b/src/Alexsoft/Curl.php
@@ -166,6 +166,7 @@ class Curl
     /**
      * @param $method string method of query
      * @return array|NULL
+     * @throws \Exception
      */
     protected function request($method)
     {
@@ -173,6 +174,9 @@ class Curl
         $this->method = $method;
         $this->prepareRequest();
         $this->response = curl_exec($this->resource);
+        if ($this->response === false) {
+            throw new \Exception(curl_error($this->resource));
+        }
         curl_close($this->resource);
         return $this->parseResponse();
     }


### PR DESCRIPTION
Hi @Daursu, I noticed that in case of curl error, for example wrong domain name, the reason of the failure is not checked with the function curl_error and the execution proceeds normally. I added an Exception containing the reason of the problem